### PR TITLE
feat: implement exercise CRUD screens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,12 +2,15 @@ import { StatusBar } from 'expo-status-bar';
 import './global.css';
 import { AppNavigator } from './src/navigation/AppNavigator';
 import { AuthProvider } from './src/contexts/AuthContext';
+import { ExerciseProvider } from './src/contexts/ExerciseContext';
 
 export default function App() {
   return (
     <AuthProvider>
-      <AppNavigator />
-      <StatusBar style="light" />
+      <ExerciseProvider>
+        <AppNavigator />
+        <StatusBar style="light" />
+      </ExerciseProvider>
     </AuthProvider>
   );
 }

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -8,6 +8,7 @@ import { useAuth } from '../contexts/AuthContext';
 // Importar telas de autenticação
 import LoginScreen from '../screens/auth/LoginScreen';
 import RegisterScreen from '../screens/auth/RegisterScreen';
+import { ExerciseNavigator } from './ExerciseNavigator';
 
 // Tipos de navegação
 export type RootStackParamList = {
@@ -23,6 +24,7 @@ export type AuthStackParamList = {
 export type MainTabParamList = {
   Dashboard: undefined;
   Workout: undefined;
+  Exercises: undefined;
   Profile: undefined;
 };
 
@@ -100,6 +102,7 @@ function MainTabNavigator() {
     >
       <Tab.Screen name="Dashboard" component={DashboardScreen} />
       <Tab.Screen name="Workout" component={WorkoutScreen} />
+      <Tab.Screen name="Exercises" component={ExerciseNavigator} />
       <Tab.Screen name="Profile" component={ProfileScreen} />
     </Tab.Navigator>
   );

--- a/src/navigation/ExerciseNavigator.tsx
+++ b/src/navigation/ExerciseNavigator.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+// Importar as telas de exercício
+import ExerciseListScreen from '../screens/exercise/ExerciseListScreen';
+import ExerciseDetailScreen from '../screens/exercise/ExerciseDetailScreen';
+import ExerciseCreateScreen from '../screens/exercise/ExerciseCreateScreen';
+import ExerciseEditScreen from '../screens/exercise/ExerciseEditScreen';
+
+export type ExerciseStackParamList = {
+  ExerciseList: undefined;
+  ExerciseDetail: { exerciseId: string };
+  ExerciseCreate: undefined;
+  ExerciseEdit: { exerciseId: string };
+};
+
+const Stack = createNativeStackNavigator<ExerciseStackParamList>();
+
+export function ExerciseNavigator() {
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        headerStyle: {
+          backgroundColor: '#1A1A1A', // forge-steel
+        },
+        headerTintColor: '#F5F5F5', // forge-light
+        headerTitleStyle: {
+          fontWeight: 'bold',
+        },
+        headerBackTitle: 'Voltar',
+      }}
+    >
+      <Stack.Screen
+        name="ExerciseList"
+        component={ExerciseListScreen}
+        options={{ headerShown: false }} // A Tab já mostra o título
+      />
+      <Stack.Screen
+        name="ExerciseDetail"
+        component={ExerciseDetailScreen}
+        options={{ title: 'Detalhes do Exercício' }}
+      />
+      <Stack.Screen
+        name="ExerciseCreate"
+        component={ExerciseCreateScreen}
+        options={{ title: 'Novo Exercício' }}
+      />
+      <Stack.Screen
+        name="ExerciseEdit"
+        component={ExerciseEditScreen}
+        options={{ title: 'Editar Exercício' }}
+      />
+    </Stack.Navigator>
+  );
+}

--- a/src/screens/exercise/ExerciseCreateScreen.tsx
+++ b/src/screens/exercise/ExerciseCreateScreen.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity, Alert, ScrollView } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useExercise } from '../../contexts/ExerciseContext';
+import { ForgeComponents, createInputStyle, createButtonStyle } from '../../styles/forgeTheme';
+
+interface ExerciseFormData {
+  name: string;
+  description: string;
+  muscleGroup: string;
+  equipment: string;
+}
+
+interface FormErrors {
+  name?: string;
+  muscleGroup?: string;
+}
+
+export default function ExerciseCreateScreen() {
+  const navigation = useNavigation();
+  const { createExercise, loading } = useExercise();
+  const [formData, setFormData] = useState<ExerciseFormData>({
+    name: '',
+    description: '',
+    muscleGroup: '',
+    equipment: '',
+  });
+  const [errors, setErrors] = useState<FormErrors>({});
+
+  const validateForm = (): boolean => {
+    const newErrors: FormErrors = {};
+    if (!formData.name.trim()) {
+      newErrors.name = 'O nome do exercício é obrigatório.';
+    }
+    if (!formData.muscleGroup.trim()) {
+      newErrors.muscleGroup = 'O grupo muscular é obrigatório.';
+    }
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSave = async () => {
+    if (!validateForm()) {
+      return;
+    }
+
+    const newExercise = await createExercise({
+      name: formData.name,
+      description: formData.description,
+      muscleGroup: formData.muscleGroup,
+      equipment: formData.equipment || 'Peso corporal',
+    });
+
+    if (newExercise) {
+      Alert.alert('Sucesso', 'Exercício criado com sucesso!');
+      navigation.goBack();
+    } else {
+      Alert.alert('Erro', 'Não foi possível criar o exercício. Tente novamente.');
+    }
+  };
+
+  return (
+    <ScrollView style={ForgeComponents.container}>
+      <Text style={ForgeComponents.title}>Novo Exercício</Text>
+
+      <View style={{ marginBottom: 20 }}>
+        <Text style={ForgeComponents.label}>Nome do Exercício</Text>
+        <TextInput
+          value={formData.name}
+          onChangeText={(text) => setFormData(prev => ({ ...prev, name: text }))}
+          placeholder="Ex: Supino Reto"
+          style={createInputStyle(!!errors.name)}
+        />
+        {errors.name && <Text style={ForgeComponents.errorText}>{errors.name}</Text>}
+      </View>
+
+      <View style={{ marginBottom: 20 }}>
+        <Text style={ForgeComponents.label}>Descrição</Text>
+        <TextInput
+          value={formData.description}
+          onChangeText={(text) => setFormData(prev => ({ ...prev, description: text }))}
+          placeholder="Ex: Deite-se no banco..."
+          multiline
+          style={[createInputStyle(false), { height: 100 }]}
+        />
+      </View>
+
+      <View style={{ marginBottom: 20 }}>
+        <Text style={ForgeComponents.label}>Grupo Muscular</Text>
+        <TextInput
+          value={formData.muscleGroup}
+          onChangeText={(text) => setFormData(prev => ({ ...prev, muscleGroup: text }))}
+          placeholder="Ex: Peito"
+          style={createInputStyle(!!errors.muscleGroup)}
+        />
+        {errors.muscleGroup && <Text style={ForgeComponents.errorText}>{errors.muscleGroup}</Text>}
+      </View>
+
+      <View style={{ marginBottom: 30 }}>
+        <Text style={ForgeComponents.label}>Equipamento (Opcional)</Text>
+        <TextInput
+          value={formData.equipment}
+          onChangeText={(text) => setFormData(prev => ({ ...prev, equipment: text }))}
+          placeholder="Ex: Barra e anilhas"
+          style={createInputStyle(false)}
+        />
+      </View>
+
+      <TouchableOpacity
+        style={createButtonStyle(loading)}
+        onPress={handleSave}
+        disabled={loading}
+      >
+        <Text style={ForgeComponents.buttonText}>
+          {loading ? 'Salvando...' : 'Salvar Exercício'}
+        </Text>
+      </TouchableOpacity>
+    </ScrollView>
+  );
+}

--- a/src/screens/exercise/ExerciseDetailScreen.tsx
+++ b/src/screens/exercise/ExerciseDetailScreen.tsx
@@ -1,0 +1,93 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, TouchableOpacity, Alert, ActivityIndicator } from 'react-native';
+import { useRoute, useNavigation, RouteProp } from '@react-navigation/native';
+import { useExercise } from '../../contexts/ExerciseContext';
+import { Exercise } from '../../database/models/Exercise';
+import { ForgeComponents, ForgeColors, createButtonStyle } from '../../styles/forgeTheme';
+
+type ExerciseDetailScreenRouteProp = RouteProp<{ params: { exerciseId: string } }, 'params'>;
+
+export default function ExerciseDetailScreen() {
+  const route = useRoute<ExerciseDetailScreenRouteProp>();
+  const navigation = useNavigation();
+  const { exerciseId } = route.params;
+
+  const { loadExerciseById, deleteExercise, loading } = useExercise();
+  const [exercise, setExercise] = useState<Exercise | null>(null);
+
+  useEffect(() => {
+    const fetchExercise = async () => {
+      const fetchedExercise = await loadExerciseById(exerciseId);
+      setExercise(fetchedExercise);
+    };
+
+    fetchExercise();
+  }, [exerciseId, loadExerciseById]);
+
+  const handleDelete = () => {
+    Alert.alert(
+      'Confirmar Exclusão',
+      `Tem certeza que deseja excluir o exercício "${exercise?.name}"?`,
+      [
+        { text: 'Cancelar', style: 'cancel' },
+        {
+          text: 'Excluir',
+          style: 'destructive',
+          onPress: async () => {
+            await deleteExercise(exerciseId);
+            navigation.goBack();
+          },
+        },
+      ]
+    );
+  };
+
+  if (loading && !exercise) {
+    return (
+      <View style={ForgeComponents.container}>
+        <ActivityIndicator size="large" color={ForgeColors.ember} />
+      </View>
+    );
+  }
+
+  if (!exercise) {
+    return (
+      <View style={ForgeComponents.container}>
+        <Text style={{ color: ForgeColors.light }}>Exercício não encontrado.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={ForgeComponents.container}>
+      <Text style={ForgeComponents.title}>{exercise.name}</Text>
+
+      <View style={ForgeComponents.card}>
+        <Text style={ForgeComponents.label}>Descrição</Text>
+        <Text style={{ color: ForgeColors.light, marginBottom: 20 }}>{exercise.description || 'N/A'}</Text>
+
+        <Text style={ForgeComponents.label}>Grupo Muscular</Text>
+        <Text style={{ color: ForgeColors.light, marginBottom: 20 }}>{exercise.muscleGroup}</Text>
+
+        <Text style={ForgeComponents.label}>Equipamento</Text>
+        <Text style={{ color: ForgeColors.light }}>{exercise.equipment}</Text>
+      </View>
+
+      <View style={{ marginTop: 30, flexDirection: 'row', justifyContent: 'space-around' }}>
+        <TouchableOpacity
+          style={[createButtonStyle(false), { flex: 1, marginRight: 10 }]}
+          onPress={() => navigation.navigate('ExerciseEdit' as never, { exerciseId: exercise.id } as never)}
+        >
+          <Text style={ForgeComponents.buttonText}>Editar</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[createButtonStyle(false), { flex: 1, marginLeft: 10, backgroundColor: ForgeColors.danger }]}
+          onPress={handleDelete}
+          disabled={loading}
+        >
+          <Text style={ForgeComponents.buttonText}>Excluir</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}

--- a/src/screens/exercise/ExerciseEditScreen.tsx
+++ b/src/screens/exercise/ExerciseEditScreen.tsx
@@ -1,0 +1,140 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, TextInput, TouchableOpacity, Alert, ScrollView, ActivityIndicator } from 'react-native';
+import { useRoute, useNavigation, RouteProp } from '@react-navigation/native';
+import { useExercise } from '../../contexts/ExerciseContext';
+import { ForgeComponents, createInputStyle, createButtonStyle, ForgeColors } from '../../styles/forgeTheme';
+
+type ExerciseEditScreenRouteProp = RouteProp<{ params: { exerciseId: string } }, 'params'>;
+
+interface ExerciseFormData {
+  name: string;
+  description: string;
+  muscleGroup: string;
+  equipment: string;
+}
+
+interface FormErrors {
+  name?: string;
+  muscleGroup?: string;
+}
+
+export default function ExerciseEditScreen() {
+  const route = useRoute<ExerciseEditScreenRouteProp>();
+  const navigation = useNavigation();
+  const { exerciseId } = route.params;
+
+  const { updateExercise, loadExerciseById, loading } = useExercise();
+  const [formData, setFormData] = useState<ExerciseFormData | null>(null);
+  const [errors, setErrors] = useState<FormErrors>({});
+
+  useEffect(() => {
+    const fetchExercise = async () => {
+      const exercise = await loadExerciseById(exerciseId);
+      if (exercise) {
+        setFormData({
+          name: exercise.name || '',
+          description: exercise.description || '',
+          muscleGroup: exercise.muscleGroup || '',
+          equipment: exercise.equipment || '',
+        });
+      }
+    };
+    fetchExercise();
+  }, [exerciseId, loadExerciseById]);
+
+  const validateForm = (): boolean => {
+    if (!formData) return false;
+    const newErrors: FormErrors = {};
+    if (!formData.name.trim()) {
+      newErrors.name = 'O nome do exercício é obrigatório.';
+    }
+    if (!formData.muscleGroup.trim()) {
+      newErrors.muscleGroup = 'O grupo muscular é obrigatório.';
+    }
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSave = async () => {
+    if (!formData || !validateForm()) {
+      return;
+    }
+
+    await updateExercise(exerciseId, {
+      name: formData.name,
+      description: formData.description,
+      muscleGroup: formData.muscleGroup,
+      equipment: formData.equipment,
+    });
+
+    Alert.alert('Sucesso', 'Exercício atualizado com sucesso!');
+    navigation.goBack();
+  };
+
+  if (!formData) {
+    return (
+      <View style={ForgeComponents.container}>
+        <ActivityIndicator size="large" color={ForgeColors.ember} />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView style={ForgeComponents.container}>
+      <Text style={ForgeComponents.title}>Editar Exercício</Text>
+
+      <View style={{ marginBottom: 20 }}>
+        <Text style={ForgeComponents.label}>Nome do Exercício</Text>
+        <TextInput
+          value={formData.name}
+          onChangeText={(text) => setFormData(prev => prev ? { ...prev, name: text } : null)}
+          placeholder="Ex: Supino Reto"
+          style={createInputStyle(!!errors.name)}
+        />
+        {errors.name && <Text style={ForgeComponents.errorText}>{errors.name}</Text>}
+      </View>
+
+      <View style={{ marginBottom: 20 }}>
+        <Text style={ForgeComponents.label}>Descrição</Text>
+        <TextInput
+          value={formData.description}
+          onChangeText={(text) => setFormData(prev => prev ? { ...prev, description: text } : null)}
+          placeholder="Ex: Deite-se no banco..."
+          multiline
+          style={[createInputStyle(false), { height: 100 }]}
+        />
+      </View>
+
+      <View style={{ marginBottom: 20 }}>
+        <Text style={ForgeComponents.label}>Grupo Muscular</Text>
+        <TextInput
+          value={formData.muscleGroup}
+          onChangeText={(text) => setFormData(prev => prev ? { ...prev, muscleGroup: text } : null)}
+          placeholder="Ex: Peito"
+          style={createInputStyle(!!errors.muscleGroup)}
+        />
+        {errors.muscleGroup && <Text style={ForgeComponents.errorText}>{errors.muscleGroup}</Text>}
+      </View>
+
+      <View style={{ marginBottom: 30 }}>
+        <Text style={ForgeComponents.label}>Equipamento (Opcional)</Text>
+        <TextInput
+          value={formData.equipment}
+          onChangeText={(text) => setFormData(prev => prev ? { ...prev, equipment: text } : null)}
+          placeholder="Ex: Barra e anilhas"
+          style={createInputStyle(false)}
+        />
+      </View>
+
+      <TouchableOpacity
+        style={createButtonStyle(loading)}
+        onPress={handleSave}
+        disabled={loading}
+      >
+        <Text style={ForgeComponents.buttonText}>
+          {loading ? 'Salvando...' : 'Salvar Alterações'}
+        </Text>
+      </TouchableOpacity>
+    </ScrollView>
+  );
+}

--- a/src/screens/exercise/ExerciseListScreen.tsx
+++ b/src/screens/exercise/ExerciseListScreen.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  TextInput,
+  ActivityIndicator,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useExercise } from '../../contexts/ExerciseContext';
+import { Exercise } from '../../database/models/Exercise';
+import { ForgeComponents, ForgeColors, createInputStyle, createButtonStyle } from '../../styles/forgeTheme';
+
+export default function ExerciseListScreen() {
+  const navigation = useNavigation();
+  const {
+    filteredExercises,
+    loading,
+    searchQuery,
+    setSearchQuery,
+    loadExercises,
+  } = useExercise();
+
+  useEffect(() => {
+    // Carregar exercícios quando a tela for montada
+    loadExercises();
+  }, []);
+
+  const renderItem = ({ item }: { item: Exercise }) => (
+    <TouchableOpacity
+      style={ForgeComponents.listItem}
+      onPress={() => navigation.navigate('ExerciseDetail' as never, { exerciseId: item.id } as never)}
+    >
+      <View>
+        <Text style={ForgeComponents.listItemTitle}>{item.name}</Text>
+        <Text style={ForgeComponents.listItemSubtitle}>{item.muscleGroup}</Text>
+      </View>
+    </TouchableOpacity>
+  );
+
+  return (
+    <View style={ForgeComponents.container}>
+      <Text role="heading" aria-level={1} style={ForgeComponents.title}>
+        Exercícios
+      </Text>
+
+      {/* Barra de Busca */}
+      <TextInput
+        placeholder="Buscar exercício..."
+        placeholderTextColor={ForgeColors.metallic}
+        value={searchQuery}
+        onChangeText={setSearchQuery}
+        style={[createInputStyle(false), { marginBottom: 20 }]}
+      />
+
+      {/* Botão de Adicionar Novo */}
+      <TouchableOpacity
+        style={createButtonStyle(false)}
+        onPress={() => navigation.navigate('ExerciseCreate' as never)}
+      >
+        <Text style={ForgeComponents.buttonText}>Adicionar Novo Exercício</Text>
+      </TouchableOpacity>
+
+      {/* Lista de Exercícios */}
+      {loading ? (
+        <ActivityIndicator size="large" color={ForgeColors.ember} style={{ marginTop: 20 }} />
+      ) : (
+        <FlatList
+          data={filteredExercises}
+          renderItem={renderItem}
+          keyExtractor={(item) => item.id}
+          style={{ marginTop: 20 }}
+          ListEmptyComponent={
+            <Text style={{ color: ForgeColors.light, textAlign: 'center', marginTop: 40 }}>
+              Nenhum exercício encontrado.
+            </Text>
+          }
+        />
+      )}
+    </View>
+  );
+}

--- a/src/screens/exercise/index.ts
+++ b/src/screens/exercise/index.ts
@@ -1,0 +1,1 @@
+// This file will export the exercise screens.

--- a/src/styles/forgeTheme.ts
+++ b/src/styles/forgeTheme.ts
@@ -112,6 +112,27 @@ export const ForgeComponents = {
     padding: ForgeSpacing.xl,
     ...ForgeShadows.md,
   },
+
+  // Estilos de Item de Lista
+  listItem: {
+    backgroundColor: ForgeColors.steelLight,
+    borderRadius: ForgeBorderRadius.md,
+    padding: ForgeSpacing.lg,
+    marginBottom: ForgeSpacing.md,
+    ...ForgeShadows.sm,
+  },
+
+  listItemTitle: {
+    fontSize: ForgeFontSizes.lg,
+    fontWeight: ForgeFontWeights.semibold,
+    color: ForgeColors.light,
+  },
+
+  listItemSubtitle: {
+    fontSize: ForgeFontSizes.sm,
+    color: ForgeColors.metallic,
+    marginTop: ForgeSpacing.xs,
+  },
   
   // Títulos
   title: {


### PR DESCRIPTION
This commit introduces the full CRUD (Create, Read, Update, Delete) functionality for exercises.

It includes:
- A new 'Exercises' tab in the main navigator.
- A dedicated stack navigator for the exercise flow.
- An `ExerciseListScreen` to display, search, and filter exercises.
- An `ExerciseDetailScreen` to view exercise details and initiate edit/delete actions.
- An `ExerciseCreateScreen` and `ExerciseEditScreen` with forms for creating and updating exercises.
- An `ExerciseContext` to manage all exercise-related state and business logic, which is now available app-wide via the `ExerciseProvider`.
- New list item styles added to `forgeTheme.ts` to maintain visual consistency.